### PR TITLE
Make sure slides directory exists

### DIFF
--- a/drawframe.py
+++ b/drawframe.py
@@ -3,6 +3,8 @@
 # More to come.
 
 from PIL import Image
+import errno
+import os
 import random
 from math import ceil
 
@@ -14,6 +16,7 @@ BLOCK_SIDE = int(SCREEN_HEIGHT/NUMROWS)
 BLOCK_SIZE = (BLOCK_SIDE,BLOCK_SIDE)
 ROWS = [BLOCK_SIDE * x for x in range(NUMROWS)]
 FRAME_COUNT = 160
+OUTPUT_DIR = 'slides'
 
 choochoo = Image.open("images/choochoo.png").resize(BLOCK_SIZE)
 redcar = Image.open("images/redcar.png").resize(BLOCK_SIZE)
@@ -27,6 +30,13 @@ moon = Image.open("images/moon.png").resize(BLOCK_SIZE)
 blank = Image.new("RGBA",BLOCK_SIZE,(0,0,0,0))
 
 def main():
+
+    # Create the output directory if it doesn't already exist
+    try:
+        os.makedirs(OUTPUT_DIR)
+    except OSError as exception:
+        if exception.errno != errno.EEXIST:
+            raise
 
     # "static" holds the elements that do not change throughout the animation.
     # That includes the train and its cars.
@@ -92,7 +102,7 @@ def main():
 
         render.paste(scenery,(-offset,0),scenery)
         
-        new_filename = "slides/img" + format(frame_number,"04d") + ".png"
+        new_filename = OUTPUT_DIR + "/img" + format(frame_number,"04d") + ".png"
         print("rendering frame " + str(frame_number) + " as " + new_filename)
         render.save(new_filename)
 

--- a/drawframe.py
+++ b/drawframe.py
@@ -2,11 +2,12 @@
 # For now, render a single frame of a @choochoobot drawing onto a canvas.
 # More to come.
 
-from PIL import Image
 import errno
-import os
-import random
 from math import ceil
+import random
+import os
+
+from PIL import Image
 
 SCREEN_WIDTH = 1920
 SCREEN_HEIGHT = 576


### PR DESCRIPTION
When I first cloned anichoochoo and ran `drawframe.py`, I got the following error:

```
garrett@Garretts-MacBook-Pro ~/c/anichoochoo> ./drawframe.py 
rendering frame 0 as slides/img0000.png
Traceback (most recent call last):
  File "./drawframe.py", line 120, in <module>
    main()
  File "./drawframe.py", line 97, in main
    render.save(new_filename)
  File "/Users/garrett/code/anichoochoo/env/lib/python3.5/site-packages/PIL/Image.py", line 1682, in save
    fp = builtins.open(filename, "wb")
FileNotFoundError: [Errno 2] No such file or directory: 'slides/img0000.png'
```

The `slides` directory didn't exist yet, so the call to `open` failed.

There are two typical solutions here:
1. Have the script ensure that the necessary directory exists before trying to open files within it
2. Add the directory to the git repo (using the "empty .gitignore" trick)

Solution 1 seems strictly better so I implemented it in this pull request. 🚋 📂 
